### PR TITLE
fix: typo from machiatto to macchiato

### DIFF
--- a/macchiatoTheme.json
+++ b/macchiatoTheme.json
@@ -1,5 +1,5 @@
 {
-  "name": "Catppuccin Machiatto",
+  "name": "Catppuccin Macchiato",
   "tab": {
     "background": "#363A4FFF",
     "showCloseButton": "always",


### PR DESCRIPTION
As far as I understand the use of "machiatto" instead of "macchiato" in the filename "machiattoTheme.json" and inside the file itself was unintentional and so i fixed it in order to maintain consistency. 

Hope this is helpful and not a misunderstanding on my part.