### PR TITLE
Remove accented e for alignment with frappeTheme.json

### DIFF
--- a/frappe.json
+++ b/frappe.json
@@ -1,5 +1,5 @@
 {
-  "name": "Catppuccin Frappé",
+  "name": "Catppuccin Frappe",
 
   "cursorColor": "#F2D5CF",
   "selectionBackground": "#626880",


### PR DESCRIPTION
Wasn't sure whether to add it in here or remove it - I went with remove since none of the other files use accented letters.

Fixes Powershell falling back to the default when trying to use Frappe.

